### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/libraries/CurieBLE/examples/Peripheral/ButtonLED/ButtonLED.ino
+++ b/libraries/CurieBLE/examples/Peripheral/ButtonLED/ButtonLED.ino
@@ -53,7 +53,7 @@ void loop() {
   char buttonValue = digitalRead(buttonPin);
 
   // has the value changed since the last read
-  boolean buttonChanged = (buttonCharacteristic.value() != buttonValue);
+  bool buttonChanged = (buttonCharacteristic.value() != buttonValue);
 
   if (buttonChanged) {
     // button state changed, update characteristics

--- a/libraries/CurieI2S/examples/I2SDMA_TXCallBack/I2SDMA_TXCallBack.ino
+++ b/libraries/CurieI2S/examples/I2SDMA_TXCallBack/I2SDMA_TXCallBack.ino
@@ -10,7 +10,7 @@
 #include <CurieI2SDMA.h>
 
 const int BUFF_SIZE=64;
-boolean blinkState = true;          // state of the LED
+bool blinkState = true;          // state of the LED
 uint32_t dataBuff[BUFF_SIZE];
 uint32_t loop_count = 0;
 void setup() 

--- a/libraries/CurieIMU/examples/FreeFallDetect/FreeFallDetect.ino
+++ b/libraries/CurieIMU/examples/FreeFallDetect/FreeFallDetect.ino
@@ -10,7 +10,7 @@
 
 #include "CurieIMU.h"
 
-boolean blinkState = false;          // state of the LED
+bool blinkState = false;          // state of the LED
 unsigned long loopTime = 0;          // get the time since program started
 unsigned long interruptsTime = 0;    // get the time when free fall event is detected
 

--- a/libraries/CurieIMU/examples/MotionDetect/MotionDetect.ino
+++ b/libraries/CurieIMU/examples/MotionDetect/MotionDetect.ino
@@ -10,7 +10,7 @@
 
 #include "CurieIMU.h"
 
-boolean blinkState = false;          // state of the LED
+bool blinkState = false;          // state of the LED
 unsigned long loopTime = 0;          // get the time since program started
 unsigned long interruptsTime = 0;    // get the time when motion event is detected
 

--- a/libraries/CurieIMU/examples/RawImuDataSerial/RawImuDataSerial.ino
+++ b/libraries/CurieIMU/examples/RawImuDataSerial/RawImuDataSerial.ino
@@ -35,7 +35,7 @@ int ax, ay, az;         // accelerometer values
 int gx, gy, gz;         // gyrometer values
 
 const int ledPin = 13;      // activity LED pin
-boolean blinkState = false; // state of the LED
+bool blinkState = false; // state of the LED
 
 int calibrateOffsets = 1; // int to determine whether calibration takes place or not
 

--- a/libraries/CurieIMU/examples/ShockDetect/ShockDetect.ino
+++ b/libraries/CurieIMU/examples/ShockDetect/ShockDetect.ino
@@ -10,7 +10,7 @@
 
 #include "CurieIMU.h"
 
-boolean blinkState = false;          // state of the LED
+bool blinkState = false;          // state of the LED
 
 void setup() {
   Serial.begin(9600); // initialize Serial communication

--- a/libraries/CurieIMU/examples/StepCount/StepCount.ino
+++ b/libraries/CurieIMU/examples/StepCount/StepCount.ino
@@ -20,9 +20,9 @@
 */
 const int ledPin = 13;
 
-boolean stepEventsEnabeled = true;   // whether you're polling or using events
+bool stepEventsEnabeled = true;   // whether you're polling or using events
 long lastStepCount = 0;              // step count on previous polling check
-boolean blinkState = false;          // state of the LED
+bool blinkState = false;          // state of the LED
 
 void setup() {
   Serial.begin(9600); // initialize Serial communication

--- a/libraries/CurieIMU/examples/ZeroMotionDetect/ZeroMotionDetect.ino
+++ b/libraries/CurieIMU/examples/ZeroMotionDetect/ZeroMotionDetect.ino
@@ -9,7 +9,7 @@
 */
 #include "CurieIMU.h"
 
-boolean ledState = false;          // state of the LED
+bool ledState = false;          // state of the LED
 void setup() {
   Serial.begin(9600); // initialize Serial communication
   while(!Serial) ;    // wait for serial port to connect.

--- a/libraries/Wire/examples/bus_scan/bus_scan.ino
+++ b/libraries/Wire/examples/bus_scan/bus_scan.ino
@@ -47,7 +47,7 @@ void setup()
   while(!Serial);
 }
 
-boolean toggle = false;          // state of the LED
+bool toggle = false;          // state of the LED
 void loop()
 {
   toggle = !toggle;


### PR DESCRIPTION
This is part of a move to encourage use of the standard `bool` type over Arduino's non-standard `boolean` type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633