### PR TITLE
Add necessary delays to SPI DigitalPotControl example

### DIFF
--- a/libraries/SPI/examples/DigitalPotControl/DigitalPotControl.ino
+++ b/libraries/SPI/examples/DigitalPotControl/DigitalPotControl.ino
@@ -63,9 +63,11 @@ void loop() {
 void digitalPotWrite(int address, int value) {
   // take the SS pin low to select the chip:
   digitalWrite(slaveSelectPin, LOW);
+  delay(100);
   //  send in the address and value via SPI:
   SPI.transfer(address);
   SPI.transfer(value);
+  delay(100);
   // take the SS pin high to de-select the chip:
   digitalWrite(slaveSelectPin, HIGH);
 }


### PR DESCRIPTION
According to https://github.com/arduino/Arduino/issues/6395, these delays are required for the SPI communication with the digital potentiometer to work.

Following recommendation from https://github.com/arduino/Arduino/pull/7404#issuecomment-378239925 (this change has already been accepted in Arduino AVR Boards).